### PR TITLE
Ignores trailing slash

### DIFF
--- a/src/match.test.ts
+++ b/src/match.test.ts
@@ -118,4 +118,32 @@ describe('match', () => {
       })
     })
   })
+
+  describe('given a path without a trailing slash', () => {
+    describe('given a matching url with a trailing slash', () => {
+      const result = match('https://test.msw.io', 'https://test.msw.io/')
+
+      it('should return match', () => {
+        expect(result).toHaveProperty('matches', true)
+      })
+
+      it('should not return any parameters', () => {
+        expect(result).toHaveProperty('params', null)
+      })
+    })
+  })
+
+  describe('given a patch with a trailing slash', () => {
+    describe('given a matching url with a trailing slash', () => {
+      const result = match('https://test.msw.io/', 'https://test.msw.io')
+
+      it('should return match', () => {
+        expect(result).toHaveProperty('matches', true)
+      })
+
+      it('should not return any parameters', () => {
+        expect(result).toHaveProperty('params', null)
+      })
+    })
+  })
 })

--- a/src/pathToRegExp.test.ts
+++ b/src/pathToRegExp.test.ts
@@ -4,21 +4,21 @@ describe('pathToRegExp', () => {
   describe('given a plain string path', () => {
     it('should transform into expression matching the string', () => {
       const exp = pathToRegExp('/users/recent')
-      expect(exp).toEqual(/\/users\/recent/g)
+      expect(exp).toEqual(/\/users\/recent\/?/g)
     })
   })
 
   describe('given a path with parameters', () => {
     it('should replace parameters with a group', () => {
       const exp = pathToRegExp('/user/:userId/')
-      expect(exp).toEqual(/\/user\/(?<userId>.+?(?=\/|$))\//g)
+      expect(exp).toEqual(/\/user\/(?<userId>.+?(?=\/|$))\/?/g)
     })
   })
 
   describe('given a path with a wildcard', () => {
     it('should handle wildcard', () => {
       const exp = pathToRegExp('/user/*/shipment')
-      expect(exp).toEqual(/\/user\/.+?\/shipment/g)
+      expect(exp).toEqual(/\/user\/.+?\/shipment\/?/g)
     })
   })
 
@@ -26,7 +26,7 @@ describe('pathToRegExp', () => {
     it('should escape the url characters', () => {
       const exp = pathToRegExp('https://api.github.com/users/:username')
       expect(exp).toEqual(
-        /https:\/\/api\.github\.com\/users\/(?<username>.+?(?=\/|$))/g,
+        /https:\/\/api\.github\.com\/users\/(?<username>.+?(?=\/|$))\/?/g,
       )
     })
   })
@@ -34,7 +34,7 @@ describe('pathToRegExp', () => {
   describe('given a url with a port', () => {
     it('should leave port number as-is', () => {
       const exp = pathToRegExp('http://localhost:4000')
-      expect(exp).toEqual(/http:\/\/localhost:4000/g)
+      expect(exp).toEqual(/http:\/\/localhost:4000\/?/g)
     })
   })
 })

--- a/src/pathToRegExp.ts
+++ b/src/pathToRegExp.ts
@@ -1,13 +1,18 @@
 /**
- * Converts a string path to regular expression.
+ * Converts a string path to a Regular Expression.
  * Transforms path parameters into named RegExp groups.
  */
 export const pathToRegExp = (path: string): RegExp => {
   const pattern = path
+    // Escape literal dots
     .replace(/\./g, '\\.')
+    // Escape literal slashes
     .replace(/\//g, '/')
+    // Ignore trailing slashes
+    .replace(/\/+$/, '')
     .replace('*', '.+?')
     .replace(/:([^\d]\w+(?=\/|$))/g, (_, match) => `(?<${match}>.+?(?=\/|$))`)
+    .concat('\\/?')
 
   return new RegExp(pattern, 'g')
 }


### PR DESCRIPTION
- Fixes #4

Trailing slashes are now ignored when matching URI against a path. This behavior is similar to Express and React Router.