### PR TITLE
Supports both parameter and wildcard in a single path

### DIFF
--- a/src/pathToRegExp.test.ts
+++ b/src/pathToRegExp.test.ts
@@ -4,21 +4,28 @@ describe('pathToRegExp', () => {
   describe('given a plain string path', () => {
     it('should transform into expression matching the string', () => {
       const exp = pathToRegExp('/users/recent')
-      expect(exp).toEqual(/\/users\/recent\/?/g)
+      expect(exp).toEqual(/\/users\/recent(\/|$)/g)
     })
   })
 
   describe('given a path with parameters', () => {
     it('should replace parameters with a group', () => {
       const exp = pathToRegExp('/user/:userId/')
-      expect(exp).toEqual(/\/user\/(?<userId>.+?(?=\/|$))\/?/g)
+      expect(exp).toEqual(/\/user\/(?<userId>.+?)(\/|$)/g)
     })
   })
 
   describe('given a path with a wildcard', () => {
     it('should handle wildcard', () => {
-      const exp = pathToRegExp('/user/*/shipment')
-      expect(exp).toEqual(/\/user\/.+?\/shipment\/?/g)
+      const exp = pathToRegExp('/user/*/shipping')
+      expect(exp).toEqual(/\/user\/.+\/shipping(\/|$)/g)
+    })
+  })
+
+  describe('given a path with parameter and wildcard', () => {
+    it('should handle both', () => {
+      const exp = pathToRegExp('/user/:userId/*')
+      expect(exp).toEqual(/\/user\/(?<userId>.+?)\/.+(\/|$)/g)
     })
   })
 
@@ -26,7 +33,7 @@ describe('pathToRegExp', () => {
     it('should escape the url characters', () => {
       const exp = pathToRegExp('https://api.github.com/users/:username')
       expect(exp).toEqual(
-        /https:\/\/api\.github\.com\/users\/(?<username>.+?(?=\/|$))\/?/g,
+        /https:\/\/api\.github\.com\/users\/(?<username>.+?)(\/|$)/g,
       )
     })
   })
@@ -34,14 +41,14 @@ describe('pathToRegExp', () => {
   describe('given a url with a port', () => {
     it('should leave port number as-is', () => {
       const exp = pathToRegExp('http://localhost:4000')
-      expect(exp).toEqual(/http:\/\/localhost:4000\/?/g)
+      expect(exp).toEqual(/http:\/\/localhost:4000(\/|$)/g)
     })
   })
 
   describe('given a string with a question mark', () => {
     it('should escape the question mark', () => {
       const exp = pathToRegExp('http://test.msw.io/api/books?id=123')
-      expect(exp).toEqual(/http:\/\/test\.msw\.io\/api\/books\?id=123\/?/g)
+      expect(exp).toEqual(/http:\/\/test\.msw\.io\/api\/books\?id=123(\/|$)/g)
     })
   })
 })

--- a/src/pathToRegExp.ts
+++ b/src/pathToRegExp.ts
@@ -12,9 +12,12 @@ export const pathToRegExp = (path: string): RegExp => {
     .replace(/\?/g, '\\?')
     // Ignore trailing slashes
     .replace(/\/+$/, '')
-    .replace('*', '.+?')
-    .replace(/:([^\d]\w+(?=\/|$))/g, (_, match) => `(?<${match}>.+?(?=\/|$))`)
-    .concat('\\/?')
+    // Replace wildcard with any single character sequence
+    .replace(/\*+/g, '.+')
+    // Replace parameters with named capturing groups
+    .replace(/:([^\d]\w+(?=\/|$))/g, (_, match) => `(?<${match}>.+?)`)
+    // Allow optional trailing slash
+    .concat('(\\/|$)')
 
   return new RegExp(pattern, 'g')
 }

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -1,6 +1,9 @@
 import { runner } from './setup/runner'
 
 runner('Path', [
+  /**
+   * Path parameter
+   */
   {
     given: '/user/:userId',
     when: [
@@ -69,6 +72,10 @@ runner('Path', [
       },
     ],
   },
+
+  /**
+   * Wildcard
+   */
   {
     given: '/user/*/messages',
     when: [
@@ -81,6 +88,82 @@ runner('Path', [
       },
       {
         actual: '/user/arbitrary/messages/more',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+      {
+        actual: '/user/',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+    ],
+  },
+  {
+    given: '/user/*/messages/*',
+    when: [
+      {
+        actual: '/user/any/messages/abc-123',
+        it: {
+          matches: true,
+          params: null,
+        },
+      },
+      {
+        actual: '/user/any/messages/any/more',
+        it: {
+          matches: true,
+          params: null,
+        },
+      },
+      {
+        actual: '/user/any/',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+    ],
+  },
+
+  /**
+   * Parameter and wildcard
+   */
+  {
+    given: '/user/:userId/*',
+    when: [
+      {
+        actual: '/user/abc-123/messages',
+        it: {
+          matches: true,
+          params: {
+            userId: 'abc-123',
+          },
+        },
+      },
+      {
+        actual: '/user/abc-123/settings/',
+        it: {
+          matches: true,
+          params: {
+            userId: 'abc-123',
+          },
+        },
+      },
+      {
+        actual: '/user/abc-123/messages/def-456',
+        it: {
+          matches: true,
+          params: {
+            userId: 'abc-123',
+          },
+        },
+      },
+      {
+        actual: '/user/abc-123',
         it: {
           matches: false,
           params: null,


### PR DESCRIPTION
## Changes

- `/user/:userId/messages/*` patterns are now supported, combining both parameters and wildcards.
- Changes how parameters are compiled to RegExp.
- Changes the trailing `\/` and line ending concatenation to the RegExp.
- Adds relevant unit tests

## GitHub

- Fixes #10