### PR TITLE
fix: parameter names with underscore

### DIFF
--- a/src/pathToRegExp.ts
+++ b/src/pathToRegExp.ts
@@ -16,7 +16,7 @@ export const pathToRegExp = (path: string): RegExp => {
     .replace(/\*+/g, '.+')
     // Replace parameters with named capturing groups
     .replace(
-      /:([^\d|^\/][a-zA-Z0-9]*(?=(?:\/|\\.)|$))/g,
+      /:([^\d|^\/][a-zA-Z0-9_]*(?=(?:\/|\\.)|$))/g,
       (_, match) => `(?<${match}>.+?)`,
     )
     // Allow optional trailing slash

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -45,6 +45,46 @@ runner('Path', [
     ],
   },
   {
+    given: '/user/:user_id',
+    when: [
+      {
+        actual: '/user/abc-123',
+        it: {
+          matches: true,
+          params: { user_id: 'abc-123' },
+        },
+      },
+      {
+        actual: '/user/abc-123/',
+        it: {
+          matches: true,
+          params: { user_id: 'abc-123' },
+        },
+      },
+      {
+        actual: '/user/',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+      {
+        actual: '/user/abc-123/messages',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+      {
+        actual: '/arbitrary/abc-123',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+    ],
+  },
+  {
     given: '/user/:userId/messages',
     when: [
       {


### PR DESCRIPTION
Closes #26

I couldn't think of any other characters that we should ignore replacing here.