### PR TITLE
fix: not consider / in the param

### DIFF
--- a/src/pathToRegExp.test.ts
+++ b/src/pathToRegExp.test.ts
@@ -11,21 +11,21 @@ describe('pathToRegExp', () => {
   describe('given a path with parameters', () => {
     it('should replace parameters with a group', () => {
       const exp = pathToRegExp('/user/:userId/')
-      expect(exp).toEqual(/\/user\/(?<userId>.+?)(\/|$)/gi)
+      expect(exp).toEqual(/\/user\/(?<userId>[^/]+?)(\/|$)/gi)
     })
   })
 
   describe('given a path with a one-character parameter', () => {
     it('should replace parameter with a group', () => {
       const exp = pathToRegExp('/user/:u')
-      expect(exp).toEqual(/\/user\/(?<u>.+?)(\/|$)/gi)
+      expect(exp).toEqual(/\/user\/(?<u>[^/]+?)(\/|$)/gi)
     })
   })
 
   describe('given a path with multiple parameters', () => {
     it('should replace each parameter with a group', () => {
       expect(pathToRegExp('/user/:userId/messages/:messageId')).toEqual(
-        /\/user\/(?<userId>.+?)\/messages\/(?<messageId>.+?)(\/|$)/gi,
+        /\/user\/(?<userId>[^/]+?)\/messages\/(?<messageId>[^/]+?)(\/|$)/gi,
       )
     })
   })
@@ -40,7 +40,7 @@ describe('pathToRegExp', () => {
   describe('given a path with parameter and wildcard', () => {
     it('should handle both', () => {
       const exp = pathToRegExp('/user/:userId/*')
-      expect(exp).toEqual(/\/user\/(?<userId>.+?)\/.+(\/|$)/gi)
+      expect(exp).toEqual(/\/user\/(?<userId>[^/]+?)\/.+(\/|$)/gi)
     })
   })
 
@@ -48,7 +48,7 @@ describe('pathToRegExp', () => {
     it('should escape the url characters', () => {
       const exp = pathToRegExp('https://api.github.com/users/:username')
       expect(exp).toEqual(
-        /https:\/\/api\.github\.com\/users\/(?<username>.+?)(\/|$)/gi,
+        /https:\/\/api\.github\.com\/users\/(?<username>[^/]+?)(\/|$)/gi,
       )
     })
   })
@@ -70,7 +70,7 @@ describe('pathToRegExp', () => {
   describe('given a path with a parameter and extension', () => {
     it('should properly parse the parameter', () => {
       const exp = pathToRegExp('/user/:userId.json')
-      expect(exp).toEqual(/\/user\/(?<userId>.+?)\.json(\/|$)/gi)
+      expect(exp).toEqual(/\/user\/(?<userId>[^/]+?)\.json(\/|$)/gi)
     })
   })
 })

--- a/src/pathToRegExp.ts
+++ b/src/pathToRegExp.ts
@@ -17,7 +17,7 @@ export const pathToRegExp = (path: string): RegExp => {
     // Replace parameters with named capturing groups
     .replace(
       /:([^\d|^\/][a-zA-Z0-9_]*(?=(?:\/|\\.)|$))/g,
-      (_, match) => `(?<${match}>.+?)`,
+      (_, match) => `(?<${match}>[^\/]+?)`,
     )
     // Allow optional trailing slash
     .concat('(\\/|$)')

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -97,6 +97,13 @@ runner('Path', [
         },
       },
       {
+        actual: '/user/abc-123/def-456/messages',
+        it: {
+          matches: false,
+          params: null,
+        },
+      },
+      {
         actual: '/user/abc-123/messages/arbitrary',
         it: {
           matches: false,


### PR DESCRIPTION
This PR will fix https://github.com/mswjs/msw/issues/444

I have remove / from the group 

```diff
--- a/src/pathToRegExp.ts
+++ b/src/pathToRegExp.ts
@@ -17,7 +17,7 @@ export const pathToRegExp = (path: string): RegExp => {
     // Replace parameters with named capturing groups
     .replace(
       /:([^\d|^\/][a-zA-Z0-9_]*(?=(?:\/|\\.)|$))/g,
-      (_, match) => `(?<${match}>.+?)`,
+      (_, match) => `(?<${match}>[^\/]+?)`,
     )
     // Allow optional trailing slash
     .concat('(\\/|$)')
```
