### PR TITLE
Exports "Path" and "Match" types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { match } from './match'
+export { Path, Match, match } from './match'
 export { pathToRegExp } from './pathToRegExp'

--- a/src/match.ts
+++ b/src/match.ts
@@ -2,7 +2,7 @@ import { pathToRegExp } from './pathToRegExp'
 
 export type Path = RegExp | string
 
-interface Match {
+export interface Match {
   matches: boolean
   params: Record<string, string>
 }


### PR DESCRIPTION
- Exports `Path` and `Match` types so that third-party libraries can type annotate their implementations properly. 