### PR TITLE
fix: add union of `null` to `Match` typings

### DIFF
--- a/src/match.ts
+++ b/src/match.ts
@@ -4,7 +4,7 @@ export type Path = RegExp | string
 
 export interface Match {
   matches: boolean
-  params: Record<string, string>
+  params: Record<string, string> | null
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "declarationDir": "./lib",
     "esModuleInterop": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "strictNullChecks": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test/**/*", "**/*.test.ts"]


### PR DESCRIPTION
Related to https://github.com/mswjs/msw/issues/682.

### What

Typings of `Match` should consider `null`. When these typings are consumed by dependent projects the typings are not identical with implementation. Current consumers are not aware of `match` returning `null`.

### How

- Added `Match` typings to include `null` as union type. 
- Enabled `strictNullChecks` in order to avoid such conflicts in future. No other issues found in current code base.
